### PR TITLE
Provide port config in quote-generator

### DIFF
--- a/quote-generator/src/conf/config.json
+++ b/quote-generator/src/conf/config.json
@@ -1,4 +1,5 @@
 {
+  "http.port": 35000,
   "companies": [
     {
       "name": "MacroHard",


### PR DESCRIPTION
`http.port` is provided in `solution/quote-generator`, not in `quote-generator` which is confusing (see 6.4 in the docs, the service will start at `:8080`, not `35000`)