### PR TITLE
Dashboard Docs - client.result() doesn't exist

### DIFF
--- a/docs-zh-cn/chapters/dashboard.adoc
+++ b/docs-zh-cn/chapters/dashboard.adoc
@@ -92,7 +92,7 @@ private void lastOperations(RoutingContext context) {
                 .setStatusCode(200)
                 .end(new JsonObject().put("message", "No audit service").encode());
         } else {
-            client.result().get("/", response -> {
+            client.get("/", response -> {
               response
                   .exceptionHandler(context::fail)
                   .bodyHandler(buffer -> {
@@ -100,7 +100,6 @@ private void lastOperations(RoutingContext context) {
                         .putHeader("content-type", "application/json")
                         .setStatusCode(200)
                         .end(buffer);
-                    client.result().close();
                   });
             })
                 .exceptionHandler(context::fail)
@@ -132,6 +131,3 @@ service.getPortfolio(function (err, res) {
 ----
 
 是的，你可以直接在你的浏览器里调用相应的服务了。
-
-
-

--- a/docs/chapters/dashboard.adoc
+++ b/docs/chapters/dashboard.adoc
@@ -121,7 +121,7 @@ private void failureAwarelastOperations(RoutingContext context) {
         .end(new JsonObject().put("message", "No audit service")
             .encode());
   } else {
-    client.result().get("/", response -> {
+    client.get("/", response -> {
       response
           .exceptionHandler(context::fail)                      <1>
           .bodyHandler(buffer -> {
@@ -129,7 +129,6 @@ private void failureAwarelastOperations(RoutingContext context) {
                 .putHeader("content-type", "application/json")
                 .setStatusCode(200)
                 .end(buffer);
-            client.result().close();
           });
     })
         .exceptionHandler(context::fail)                        <2>
@@ -288,6 +287,3 @@ service.getPortfolio(function (err, res) {
 ----
 
 Yes, you can call the service method directly from your browser.
-
-
-


### PR DESCRIPTION
Small changes:
- delete calling client.result()
- don't close client inside response handler

Thank you for awesome example! :)