### PR TITLE
Two compiler warning fixes due to generics

### DIFF
--- a/vertx-workshop-common/src/main/java/io/vertx/workshop/common/MicroServiceVerticle.java
+++ b/vertx-workshop-common/src/main/java/io/vertx/workshop/common/MicroServiceVerticle.java
@@ -34,7 +34,7 @@ public class MicroServiceVerticle extends AbstractVerticle {
     publish(record, completionHandler);
   }
 
-  public void publishMessageSource(String name, String address, Class contentClass, Handler<AsyncResult<Void>>
+  public void publishMessageSource(String name, String address, Class<?> contentClass, Handler<AsyncResult<Void>>
       completionHandler) {
     Record record = MessageSource.createRecord(name, address, contentClass);
     publish(record, completionHandler);
@@ -46,7 +46,7 @@ public class MicroServiceVerticle extends AbstractVerticle {
     publish(record, completionHandler);
   }
 
-  public void publishEventBusService(String name, String address, Class serviceClass, Handler<AsyncResult<Void>>
+  public void publishEventBusService(String name, String address, Class<?> serviceClass, Handler<AsyncResult<Void>>
       completionHandler) {
     Record record = EventBusService.createRecord(name, address, serviceClass);
     publish(record, completionHandler);


### PR DESCRIPTION
Unfortunately it is not possible to clean out all compiler warnings in this file without using `@SuppressWarnings`, but it is a start 😉 