### PR TITLE
Fixed comments looks like they are swapped

### DIFF
--- a/quote-generator/src/main/java/io/vertx/workshop/quote/GeneratorConfigVerticle.java
+++ b/quote-generator/src/main/java/io/vertx/workshop/quote/GeneratorConfigVerticle.java
@@ -26,11 +26,12 @@ public class GeneratorConfigVerticle extends MicroServiceVerticle {
     JsonArray quotes = config().getJsonArray("companies");
     for (Object q : quotes) {
       JsonObject company = (JsonObject) q;
-      // Deploy the verticle with a configuration.
+    // Deploy another verticle without configuration.  
       vertx.deployVerticle(MarketDataVerticle.class.getName(), new DeploymentOptions().setConfig(company));
     }
 
-    // Deploy another verticle without configuration.
+    
+    // Deploy the verticle with a configuration.
     vertx.deployVerticle(RestQuoteAPIVerticle.class.getName(), new DeploymentOptions().setConfig(config()));
 
     // Publish the services in the discovery infrastructure.


### PR DESCRIPTION
// Deploy another verticle without configuration.  
was near a method where  configuration was being passed

// Deploy the verticle with a configuration.
was near a method where no configuration was being passed
