### PR TITLE
Fixed audit service discovery issue

### DIFF
--- a/audit-service/src/conf/config.json
+++ b/audit-service/src/conf/config.json
@@ -1,4 +1,5 @@
 {
+  "http.port": 36000,
   "url": "jdbc:hsqldb:file:audit-db;shutdown=true",
   "driverclass" : "org.hsqldb.jdbcDriver"
 }


### PR DESCRIPTION
DashboardVerticle relies on servicediscovery to discover audit-service.
But AuditVerticle does not publish the endpoint. So dashboard does not show the operations.

To fix this, publish audit service endpoint.

Port zero is a reserved port. So changed the audit service port to 36000.