### PR TITLE
fixed compilation problem: getDouble(int) doesn't exist for type Buffer

### DIFF
--- a/solution/portfolio-service/src/main/java/io/vertx/workshop/portfolio/impl/PortfolioServiceImpl.java
+++ b/solution/portfolio-service/src/main/java/io/vertx/workshop/portfolio/impl/PortfolioServiceImpl.java
@@ -94,7 +94,7 @@ public class PortfolioServiceImpl implements PortfolioService {
       if (ar.succeeded()) {
         HttpResponse<JsonObject> response = ar.result();
         if (response.statusCode() == 200) {
-          double v = numberOfShares * response.body().getDouble("bid");
+          double v = numberOfShares * response.body().toJsonObject().getDouble("bid");
           future.complete(v);
         } else {
           future.complete(0.0);


### PR DESCRIPTION
fixed issue: getDouble(int) in the type Buffer is not applicable for the arguments (String)
getDouble("bid") should be applied on json object representation of the http response body